### PR TITLE
fix(CMakeLists.txt): Release flags (e.g. -DNDEBUG) now applied when relasing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(SYSTEM ${HEXCHAT_INCLUDE_DIRS})
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_EXTENSIONS OFF)
 if(CMAKE_COMPILER_IS_GNUCC)
-    add_compile_options(-Wall -Wextra -pedantic)
+    add_compile_options(-Wall -Wextra -pedantic ${CMAKE_C_FLAGS_RELEASE})
 endif()
 
 add_library(autoaway MODULE autoaway.c)


### PR DESCRIPTION
The `CMAKE_C_FLAGS_RELEASE` is not used when releasing.
Consequently, a lot of debug messages appears in chat in production.

This patch fixes it by applying release flags when compiling.