### PR TITLE
feat(away-nick-suffix): append away suffix to nickname

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Settings list:
   (default: empty)
 * `back_extra`: Extra per-server command to execute when returning back
   (default: empty)
+* `away_nick_suffix`: The string to be appended to nick name. e.g. `|away`
+  (default: empty)
+* `away_nick_net`: The comma-seperated list of network that `away_nick_suffix` applied when away. e.g. `net1,net2`
+  (default: empty)
 
 To execute multiple extra commands on away/back, create a text file with
 the commands and set `away_extra`/`back_extra` to `LOAD -e <file>`.


### PR DESCRIPTION
This PR add functionality to add suffix to nickname when you are away (e.g. nickname|away) and remove the suffix when you are back.

Note that some networks embrace nickname change, but others loathe it, thus `away_nick_net` also implemented so user can specify which networks to change nickname. Nickname on other networks will not be touched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andreyv/hexchat-autoaway/3)
<!-- Reviewable:end -->
